### PR TITLE
Fixed some spelling mistakes

### DIFF
--- a/BSD/ext3.html
+++ b/BSD/ext3.html
@@ -175,7 +175,7 @@ files.
 <P>
 <H4>3.4 File System Tuning Parameters</h4>
 <P>
-We are often forced to make trade-offs between how rappidly we can
+We are often forced to make trade-offs between how rapidly we can
 perform various operations, and how efficiently we use space.  BSD
 file systems have per file system tuning paremeters that permit
 system managers to make different trade-offs on different file
@@ -248,7 +248,7 @@ same administrative information in their I-nodes:
 </UL>
 <P>
 Most UNIX-based file systems also use a block-pointer scheme with
-direct, indirect, double-indirect, and tripple-indirect blocks.
+direct, indirect, double-indirect, and triple-indirect blocks.
 <P>
 <CENTER>
 <IMG src="bsdinode.gif">
@@ -256,7 +256,7 @@ direct, indirect, double-indirect, and tripple-indirect blocks.
 <P>
 BSD file systems are fairly traditional in this respect (with twelve
 direct pointers, one indirect, one double-indirect, and one 
-tripple-indirect pointer) ... but they do introduce one interesting
+triple-indirect pointer) ... but they do introduce one interesting
 twist: fragment blocks.
 <P>
 <H4>4.1 Fragment Blocks</H4>
@@ -333,7 +333,7 @@ a pointer to the I-node for the parent directory.
 <P>
 <H4>6.1 Long File Names</h4>
 <P>
-A fully qualified path name can be very long (if the file is nestled
+A fully qualified path name can be very long (if the file is nested
 deep in a directory hierarchy), but each element of the file name
 was limited to be 14 bytes or less.  Many people complained about
 this limitation.

--- a/BSD/oldunix.html
+++ b/BSD/oldunix.html
@@ -19,7 +19,7 @@ power and generality of larger timesharing systems (most notably
 Multics) with a much smaller and simpler implementation.  
 Their original UNIX file system design 
 provided very reasonable functionality with relatively simple
-mechanisms.  Their file system implementatin, like so many 
+mechanisms.  Their file system implementation, like so many 
 other parts of UNIX, emphasized simplicity over functionality.
 UNIX file systems worked pretty well, and for many years the
 only changes made to them were to move to larger block sizes

--- a/DOS/dos.html
+++ b/DOS/dos.html
@@ -580,7 +580,7 @@ may be) covers their needs pretty well.
 <P>
 It is also noteworthy that when Microsoft was finally forced 
 to change the file system format to get past the 8.3 upper
-case file name limitations, they chose to do so with a klugy
+case file name limitations, they chose to do so with a kludgy
 (but upwards compatible) solution using additional directory
 entries per file.  The fact that they chose such an implementation
 clearly illustrates the importance of maintaining media 

--- a/authservers.html
+++ b/authservers.html
@@ -85,11 +85,11 @@ When the server receives the work ticket, it can verify the authentication
 server's signature and so trust that the client has been authenticated.
 Because the server ticket was encrypted with the server's key, the client
 can be sure that the agent at the other end of the connection is the
-requested server; Nobody else could decrypt the session key in the
+requested server; nobody else could decrypt the session key in the
 server ticket.
 Because the server ticket had also been encrypted with
 the client's key, the server can be sure that the agent at the other
-end of the connection is the authenticated client;  Nobody else
+end of the connection is the authenticated client; nobody else
 could have decrypted and forwarded the server ticket.
 </P>
 <H2>Work Tickets without Public Key Encryption</H2>

--- a/avoidance.html
+++ b/avoidance.html
@@ -51,8 +51,8 @@ reserve their resources before they actually need them.
 </P>
 <P>
 Consider the <em>sbrk(2)</em> system call.  It does not actually 
-allocate any more memory to the process.  It requests the Operating
-System to change the size of the data segment in the process' virtual
+allocate any more memory to the process.  It requests the operating
+system to change the size of the data segment in the process' virtual
 address space.  The actual memory assignments will not happen until
 the process begins referencing those newly authorized pages.
 If we can determine that the requested reservation would over-tax
@@ -99,7 +99,7 @@ demand that we cannot gracefully handle.
 	99.9% of the time.</li>
     <li>In operating systems, the notion of killing random
         processes is so abhorrent that most operating systems
-	simply refuse to over-book.  Infact, it is common
+	simply refuse to over-book.  In fact, it is common
 	to under-book (e.g. reserve the last 10% for 
 	emergency/super-user use).</li>
 </ul>

--- a/distsystems.html
+++ b/distsystems.html
@@ -254,10 +254,10 @@ happen in smaller systems, we can only learn about them
 through (hard) experience.
 </P>
 
-<h3>Peter Deutsch's "Seven Falacies" of Distributed Computing</h3>
+<h3>Peter Deutsch's "Seven Fallacies" of Distributed Computing</h3>
 <P>
-In 1994, Peter Deutsch looked back at a decade of failed distributed computing projets 
-and attempted to distil lessons.  He came to the conclusion that many projects had
+In 1994, Peter Deutsch looked back at a decade of failed distributed computing projects 
+and attempted to distill lessons.  He came to the conclusion that many projects had
 failed because of a few naive assumptions that proved to be disastrously false.
 He enumerated them in an often cited paper:
 </p>

--- a/dynamicmodules.html
+++ b/dynamicmodules.html
@@ -188,7 +188,7 @@ When all open file descriptors into those devices have been closed
 and the driver is no-longer needed, the operating system can call an
 shut-down method that will cause the driver to:
 <ul>
-    <li>un-register itself as a device driver</li>
+    <li>unregister itself as a device driver</li>
     <li>shut down the devices it had been managing</li>
     <li>return all allocated memory and I/O resources back to the operating system.</li>
 </ul>
@@ -199,7 +199,7 @@ After which, the module can be safely unloaded and that memory freed as well.
 All of this his completely dependent on stable and well specified interfaces:
 <ul>
    <li> the set of entry-points for any class of device driver must
-   	be well defined, and all drivers must compatably implement
+   	be well defined, and all drivers must compatibly implement
 	all of the relevant interfaces.</li>
    <li> the set of functions within the main program (OS) that the
    	dynamically loaded modules are allowed to call must be well
@@ -212,7 +212,7 @@ If one device driver did not implement a standard entry point in the standard
 way, clients of that device would not work.  Some functionality may be
 optional, and it may be acceptable for a device driver to refuse some requests.
 But this may make the application responsible for dealing with version
-some incompatabilities.
+some incompatibilities.
 </p>
 <P>
 If an operating system does not implement some standard service function
@@ -241,7 +241,7 @@ removed from the bus.  In many systems a hot-plug manager:
 </ul>
 </P>
 <P>
-Hot-plugable busses often have multiple power levels, and a newly inserted
+Hot-pluggable busses often have multiple power levels, and a newly inserted
 device may receive only enough power to enable it to be queried and configured.
 When the driver is ready to start using the device, it can instruct the bus
 to fully power the device.

--- a/filetypes.html
+++ b/filetypes.html
@@ -228,7 +228,7 @@ to persistent byte streams.
 
 <H2>4. File Attributes</h2>
 <P>
-Most of the above has treated files as containers (or access portals) 
+Most of the above have treated files as containers (or access portals) 
 for data.  But even a file of ASCII text (e.g. this HTML) is more than 
 than the bytes it contains.  In addition to <em>data</em>, files also
 have <em>meta-data</em> ... data that describes data.

--- a/gc_defrag.html
+++ b/gc_defrag.html
@@ -1,10 +1,10 @@
 <html>
 <head>
-<title>Garbage Collection and De-Fragmentation</title>
+<title>Garbage Collection and Defragmentation</title>
 </head>
 <body>
 <center>
-<h1>Garbage Collection and De-Fragmentation</h1>
+<h1>Garbage Collection and Defragmentation</h1>
 </center>
 <h2>Introduction</h2>
 <P>
@@ -17,8 +17,8 @@ fifty years are:
 <ol type="1">
 	<li>Garbage Collection ... seeking out no-longer-in-use resources and recycling them
 	   for reuse</li>
-	<li>De-Fragmentation ... re-assigning and relocating previously allocated resources to 
-	    eliminate <em>external fragmentation</em> to create densly allocated resources
+	<li>Defragmentation ... reassigning and relocating previously allocated resources to 
+	    eliminate <em>external fragmentation</em> to create densely allocated resources
 	    with large contiguous pools of free space</li>
 </ol>
 These two techniques are, in principle, orthogonal ...  but we discuss them together for
@@ -128,7 +128,7 @@ in the address space it is trying to analyze.
 </P>
 
 <A name="Defrag">
-<h2>De-Fragmentation</h2>
+<h2>Defragmentation</h2>
 <P>
 The second problem to be addressed is <em>external fragmentation</em>.  We observed that
 all variable partition memory allocation algorithms eventually result in a loss of useful
@@ -145,24 +145,24 @@ How important is contiguous allocation?
    <li>	if we are allocating blocks of disk, the only cost of non-contiguous allocation may
         be more and longer seeks, resulting in slower file I/O.</li>
    <li> if we are allocating memory to an application that needs to create a single 1024 byte
-        data structure, the program will not work with four dis-contiguous 256 byte chunks
+        data structure, the program will not work with four discontiguous 256 byte chunks
 	of memory.</li>
    <li> Solid State Disks (based on NAND-Flash technology) may allocate space one
-        4K block at a time; but before that block can be re-written with new data
+        4K block at a time; but before that block can be rewritten with new data
 	it must be erased ... and erasure operations might be performed 64MB at a
 	time.
 </ul>
 </P>
 <P>
 Garbage Collection analyzes the allocated resources to determine which ones are still
-in use.  De-Fragmentation goes farther.  It actually changes which resources are allocated.
+in use.  Defragmentation goes farther.  It actually changes which resources are allocated.
 Consider two applications of de-fragmentation:
 <UL>
    <LI> Flash Management
         <p>
 	NAND Flash is a pseudo-Write-Once-Read-Many medium.  After a block has been written,
 	some serious processing and voltage will be required to erase it before it can be
-	re-written with new data.  When the operating system does a write to an SSD, 
+	rewritten with new data.  When the operating system does a write to an SSD, 
 	firmware in the Flash Controller assigns a new block to receive the new data 
 	(leaving the old contents no longer referenced).
 	As more and more 4K blocks become stale.  Half of all the blocks in the SSD
@@ -185,10 +185,10 @@ Consider two applications of de-fragmentation:
    <LI> Disk Space Allocation
         <p>
 	File reads and writes can progress orders of magnitude more quickly if logically
-	consecutibe blocks are stored contiguously on disk (so they can be read in a
+	consecutive blocks are stored contiguously on disk (so they can be read in a
 	single operation with no head movement).  But eventually, after many generations
 	of files being created and deleted, the free space, and many files become
-	dis-contiguous, and the file systems become slower and slower.
+	discontiguous, and the file systems become slower and slower.
 	</p>
    	<p>
 	To clean up the free space and restore our previous performance, we need to follow
@@ -215,7 +215,7 @@ In neither of these examples is defragmentation a one-time process.  Internal fr
 In the first (flash management) example the process is (like progressive garbage collection) a continuous one.
 In older file systems (e.g. Windows FAT file systems), the process was more likely periodic; Once or twice a year 
 we take the file system down to run defragmentation, after which performance should be good for a few more months.
-But in some newer file systems (e.g. the B-TRee File System) de-fragmentation is also a continuously ongoing process.
+But in some newer file systems (e.g. the B-TRee File System) defragmentation is also a continuously ongoing process.
 </p>
 <h2>Conclusions</h2>
 <P>
@@ -231,7 +231,7 @@ can be applied to a surprisingly wide range of resource allocation problems:
 	resources discoverable, how you will trigger the scans, and how you will prevent race
 	conditions between the Garbage Collector and your application.</li>
    <li> If your resource is subject to degradation or loss due to external fragmentation, you 
-   	should consider whether or not periodic Defragmentation can mitigate that process.
+   	should consider whether or not periodic defragmentation can mitigate that process.
 	If you want to use Defragmentation, you must figure out how you will drive the
 	process, and how you will accomplish the required resource reallocation and copying
 	without disrupting the running applications.</li>

--- a/horizontal.html
+++ b/horizontal.html
@@ -111,7 +111,7 @@ the performance of (much more expensive) custom-built hardware.
 If a horizontally scalable system is comprised of many servers,
 and new servers can be added at any time, it is essential that
 they all have appropriate network connectivity (for client-facing
-traffic, back-side servers, and peer-to-perr replication).  It is
+traffic, back-end servers, and peer-to-peer replication).  It is
 not practical to rack new switches and connect new cables each time
 a new server is to be integrated into a particular service.  
 Rather, large computing facilities are moving towards
@@ -180,7 +180,7 @@ made known to a network switch that starts sending it requests.
 <UL>
    <li>	Since HTTP is a stateless protocol, the switch can 
    	route any request to any server. This routing may be 
-	as simple as round-robbin, or it may be load-balanced 
+	as simple as Round-Robbin, or it may be load-balanced 
 	based on measured response times to recent requests.</li>
    <li> Parallel servers have no need to communicate with one-another, 
    	and the only configuration a web server requires is knowing 
@@ -199,11 +199,11 @@ Even non-RESTful services can benefit from horizontal scaling.
 Consider the <em>shopping carts</em> supported by many product web sites.
 The front-end web-servers are indeed horizontally scaled and stateless.
 Shopping cart display and update operations are forwarded from the
-responding web-server to a back-end data-base server.  The back-end
-data-base server may be highly stateful, and not at all horizontally
+responding web-server to a back-end database server.  The back-end
+database server may be highly stateful, and not at all horizontally
 scalable.  But if 99.9% of all requests can be satisfied by the
 front line of web servers, it may be much easier to build a
-(perhaps vertically scaled) data-base server to handle the
+(perhaps vertically scaled) database server to handle the
 shopping cart requests.
 </P>
 <P>
@@ -217,7 +217,7 @@ some servers fail.  Imposing a low cap on the number of servers
 involved in any particular transaction enables the protocols to
 scale to thousands of nodes with no degradataion in performance.
 When we need to add capacity, we do not add more servers for a 
-particular shard; Rather we increase the number of shards into 
+particular shard; rather, we increase the number of shards into 
 which the name space is divided, and assign the new shards to
 new servers.
 Similar techniques have been employed to improve the scalability of 

--- a/interfaces.html
+++ b/interfaces.html
@@ -8,7 +8,7 @@ Software Interface Standards
 </H1></center>
 <h2>Introduction</h2>
 <P>
-Over two-thousand years ago, Carthage defined standard component sizes for their naval vessels, 
+Over two thousand years ago, Carthage defined standard component sizes for their naval vessels, 
 so that parts from one ship could be used to repair another.  Slightly more recently, George 
 Washington gave Eli Whitney a contract to build 12,000 muskets with interchangeable parts.
 The standardization of component interfaces makes it possible to successfully combine or 
@@ -225,7 +225,7 @@ When faced with such change we find ourselves forced to choose between:
 	<li>A compromise that partially supports new technologies and 
 	    applications, while remaining mostly compatible with old 
 	    interfaces.   This is the path most commonly taken, but 
-	    it often proves to be both un-competitive and incompatible.</li>
+	    it often proves to be both uncompetitive and incompatible.</li>
 </ul>
 </P>
 <P>

--- a/inversion.html
+++ b/inversion.html
@@ -112,7 +112,7 @@ normal priority, allowing me to preempt it.
 Priority Inversion can happen whenever processes (or threads) of different priority
 share a serialized resource.  In the collisions are rare, and the lower priority
 process runs (and completes) soon enough, the problem may go unnoticed.
-But eventually, a situation will arrise wherein the imposed delays cause
+But eventually, a situation will arise wherein the imposed delays cause
 externally observable problems.  It is often the case with timing errors
 that they happen regularly, but are only discovered when the consequences
 are serious enough to be noticed.   If we know that a certain computation

--- a/ipc.html
+++ b/ipc.html
@@ -42,7 +42,7 @@ All such uses have a few key characteristics in common:
    <li> Each program accepts a byte-stream input, and produces a
         byte-stream output that is a well defined function of
 	the input.</li>
-   <li> Each program in the pipe-line operates independently, and
+   <li> Each program in the pipeline operates independently, and
         is unaware that the others exist or what they might do.</li>
    <li> Byte streams are inherently unstructured.  If there is any 
         structure to the data they carry (e.g. newline-delimited 
@@ -85,7 +85,7 @@ initial input files and final output files.  There is generally
 no authentication or encryption of the data being passed between
 successive processes in the pipeline.
 </P>
-<H2>Named Pipes and Mail-Boxes</H2>
+<H2>Named Pipes and Mailboxes</H2>
 <P>
 A named-pipe (<em>fifo(7)</em>) is a baby-step towards explicit connections.
 It can be thought of as a persistent pipe, whose reader and writer(s) can
@@ -143,12 +143,12 @@ communications APIs.  The associated Linux APIs ar:
 These APIs directly provide a range of different communications options:
 <UL>
    <li> byte streams over reliable connections (e.g. TCP)</li>
-   <li> best effort data-grams (e.g. UDP)</li>
+   <li> best effort datagrams (e.g. UDP)</li>
 </UL>
 But they also form a foundation for higher level communication/service models.
 A few examples include:
 <UL>
-   <LI>Remote Procedure Calls ... distribued request/response APIs.</li>
+   <LI>Remote Procedure Calls ... distributed request/response APIs.</li>
    <LI>RESTful service models ... layered on top of HTTP GETs and PUTs.</li>
    <LI>Publish/Subscribe services ... content based information flow.</li>
 </UL>
@@ -214,7 +214,7 @@ is through shared memory:
 </ul>
 <P>
 Once the shared segment has been created and mapped into the participating
-process' address spaces, the Operating System plays no role in the
+process' address spaces, the operating system plays no role in the
 subsequent data exchanges.
 Moving data in this way is extremely efficient and blindingly fast ... 
 but (like all good things) this performance comes at a price:

--- a/leases.html
+++ b/leases.html
@@ -200,7 +200,7 @@ dealt with through the centralized lock manager.
 <H2>Summary</h2>
 <P>
 Locks are a fundamental concept, but one from a simpler time.
-They are ignorant of Deutsch's Seven Falacies, and do not work well in distributed systems.
+They are ignorant of Deutsch's Seven Fallacies, and do not work well in distributed systems.
 Leases are a richer and more expensive mechanism that more robustly embraces these
 more complex situations.  These capabilities make them interesting even in single-node
 applications where locking must be robust in the face of an ever-changing set of clients.

--- a/leases.html
+++ b/leases.html
@@ -12,7 +12,7 @@ Leases represent a very different, and much more robust approach to serializatio
 </P>
 <h2>Challenges of Distributed Locking</h2>
 <P>
-Among Deutsch's Seven Falacies of distributed computing were:
+Among Deutsch's Seven Fallacies of distributed computing were:
 <ul>
 	<li> zero latency </li>
 	<li> reliable delivery </li>
@@ -98,7 +98,7 @@ It does not matter why a lease may have expired:
    <li> the owning process is running slowly </li>
    <li> the network connection to the owning node has failed </li>
 </ul>
-What ever the reason for the expiration, the lease is no longer valid,
+Whatever the reason for the expiration, the lease is no longer valid,
 operations from the previous owner will no longer be accepted, and 
 the lease can be granted to a new requestor.
 This means that the system can automatically recover from any failure

--- a/linkage.html
+++ b/linkage.html
@@ -86,9 +86,9 @@ The basic elements of subroutine linkage are:
 	<li> subroutine call ... save the return address (in the calling routine)
 		on the stack, and transfer control to the entry point (of the called routine).</li>
 	<li> register saving ... saving the contents of registers that the linkage
-		conventions delclare to be <em>non-volatile</em>, so that they can
-		be restored when the called routine returne.</li>
-	<li> allocating space for the local variables (and perhaps computationsl
+		conventions declare to be <em>non-volatile</em>, so that they can
+		be restored when the called routine returns.</li>
+	<li> allocating space for the local variables (and perhaps computational
 		temporaries) in the called routine.</li>
 </ul>
 When the called routine completes, the process of returning is fairly symmetric:

--- a/linkage.html
+++ b/linkage.html
@@ -50,7 +50,7 @@ Consider the recursive factorial implementation:
 </tt></pre>
 </ul>
 </p>
-If I call <tt>factoria(4)</tt>, just before the final invocation
+If I call <tt>factorial(4)</tt>, just before the final invocation
 of <tt>factorial</tt> returns, there would be four instances of
 <tt>factorial</tt> on the stack, in addition to the call frames
 for the code that called <tt>factorial</tt> in the first place.
@@ -210,7 +210,7 @@ The key differences between a procedure call and an interrupt/trap are:
 </UL>
 </P>
 <P>
-A typical interrupt or trap mechanisnm works as follows:
+A typical interrupt or trap mechanism works as follows:
 <UL>
    <LI> there is a number (0, 1, 2 ...) associated with every possible
 	external interrupt or execution exception.</li>

--- a/loadstress.html
+++ b/loadstress.html
@@ -122,7 +122,7 @@ In all cases, the test load is broadly characterized in terms of:
 	 may be critical to simulate particular access patterns 
 	 (timed sequences operations on related objects). 
 	 In some situations it may be necessary to simulate realistic
-	 scenarios against pre-determined or random objects.
+	 scenarios against predetermined or random objects.
 </ul>
 <P>
 A good load generator will be tunable in terms of both the overall
@@ -146,12 +146,12 @@ assessment:
    <LI> Deliver requests at increasing rates until a maximum throughput
 	is reached.
    <LI> Deliver requests at a rate, and use this as a calibrated 
-	back-ground for measuring the performance other system services.
+	background for measuring the performance other system services.
    <LI> Deliver requests at a rate, and use this as a test load for
 	detailed studies performance bottlenecks.
 </ol>
 In the first two usages, the load generator is a measurement tool.
-In the other usages, it provides a calibrated activity mix,
+In the other usages, it provides a calibrated activity mix
 to exercise the system.
 <P>
 <H3>2.3 Accelerated Aging</h3>

--- a/loadstress.html
+++ b/loadstress.html
@@ -169,7 +169,7 @@ such problems.
 Load generators are (fundamentally) intended to generate request
 sequences that are representative of what the measured system will experience
 in the field.  Accelerated Aging uses cranked up load generators
-to simulate longer periods of use.  If we go farther (into simulating
+to simulate longer periods of use.  If we go further (into simulating
 scenarios far worse than anything that is ever expected to really
 happen) we enter the realm of stress testing.
 <P>

--- a/multiprocessor.html
+++ b/multiprocessor.html
@@ -223,7 +223,7 @@ available.  The operating system will try to make intelligent decisions,
 but if the developers understand how work can best be allocated 
 among multi-processor cores, they can advise the operating system
 with operations like
-<em>sched_setaffinity(2)</em> and <em>ptrhead_setaffinity_np(3)</em>.
+<em>sched_setaffinity(2)</em> and <em>pthread_setaffinity_np(3)</em>.
 </p>
 
 <H3>Synchronization</H3>

--- a/multiprocessor.html
+++ b/multiprocessor.html
@@ -37,8 +37,8 @@ bigger computer every year.
 </P>
 <P>
 Long ago it was possible to make computers faster by shrinking the gates, speeding up the
-clock, and improving the cooling.  But eventually we reach a point of dimmisnishing
-returns where  physics (the speed of light,
+clock, and improving the cooling.  But eventually we reach a point of diminishing
+returns where physics (the speed of light,
 information theory, thermodynamics) makes it ever more difficult to build faster
 CPUs.  Recently, most of our improvements in processing speed have come from:
 <UL>
@@ -61,7 +61,7 @@ job of exploiting them.
 </P>
 <H2>Multi-Processor Hardware</H2>
 <P>
-The above general defintion covers a wide range of architectures, that actually
+The above general definition covers a wide range of architectures, that actually
 have very different characteristics.  And so it is useful, to overview the most
 prominent architectures.
 
@@ -70,7 +70,7 @@ prominent architectures.
 CPUs are much faster than memory.  
 A 2.5GHz CPU might be able to execute more than 5 Billion instructions for second.
 Unfortunately, 80ns memory can only deliver 12 Million fetches or stores per second.  
-This is almost a 1000x mis-match in performance.
+This is almost a 1000x mismatch in performance.
 The CPU has multiple levels of cache to ensure that we seldom have to go to memory,
 but even so, the CPU spends a great deal of time waiting for memory.
 </P>
@@ -78,7 +78,7 @@ but even so, the CPU spends a great deal of time waiting for memory.
 The idea of hyper-threading is to give each core two sets of general registers, and the ability
 to run two independent threads.  When one of those threads is blocked (waiting for memory)
 the other thread can be using the execution engine.   Think of this as non-preemptive
-time-sharing at the micro-code level.  It is comon for a pair of hyper-threads
+time-sharing at the micro-code level.  It is common for a pair of hyper-threads
 to get 1.2-1.8 times the instructions per second that a single thread would have gotten on
 the same core.  It is theoretically possible to get 2x hyper-threading, but a thread might
 run out of L1 cache for a long time without blocking, or perhaps both hyper-threads
@@ -189,7 +189,7 @@ what resources to allocate to them.
 <P>
 When we looked at distributed systems, we saw (e.g. 
 <a href="https://en.wikipedia.org/wiki/Fallacies_of_distributed_computing">
-Deutsch's Seven Falacies</a>) that the mere fact that a network is
+Deutsch's Seven Fallacies</a>) that the mere fact that a network is
 capable of distributing every operation to an arbitrary node 
 does not make doing so a good idea.  
 It will be seen that the same caveat applies to multi-processor systems.
@@ -223,7 +223,7 @@ available.  The operating system will try to make intelligent decisions,
 but if the developers understand how work can best be allocated 
 among multi-processor cores, they can advise the operating system
 with operations like
-<em>sched_setaffinity(2)</em> and <em>pthead_setaffinity_np(3)</em>.
+<em>sched_setaffinity(2)</em> and <em>ptrhead_setaffinity_np(3)</em>.
 </p>
 
 <H3>Synchronization</H3>
@@ -322,7 +322,7 @@ copy of a (read only) load module among all processes that were
 running that program.  This ceases to be true when those processes
 are running on distinct NUMA nodes.  Code and other read-only data
 should be have a separate copy (in local memory) on each NUMA node.
-The cost (in terms of wasted memory) is neglibile in comparison
+The cost (in terms of wasted memory) is negligible in comparison
 performance gains from making all code references local.
 </P>
 <P>
@@ -372,3 +372,4 @@ maintainability over performance and scalability.
 </P>
 
 </BODY>
+</HTML>

--- a/objmods.html
+++ b/objmods.html
@@ -12,7 +12,7 @@ Object Modules, Linkage Editing, Libraries
 One of the most fundamental abstract resources implemented by an operating system is the process.  A process is often defined as an executing instance of a program.  If we want to understand what a process is, it is very helpful to understand what a program is.  We most often think of a program as one or more files (e.g. C, Java, Python).  These are not executable programs, but rather source files that can be translated into machine language and combined with other machine language modules to create executable programs.
 </p>
 <p>
-From the Operating System’s perspective, a program is a file full of ones and zeros, that when loaded into memory, become machine-language instructions that can be executed by the computer on which we are running.   
+From the operating system’s perspective, a program is a file full of ones and zeros, that when loaded into memory, become machine-language instructions that can be executed by the computer on which we are running.   
 <ul>
 	<li> How do our source modules come to be translated into machine language instructions?</li>
 	<li> How do they come to be combined with other machine language modules to form complete programs?</li>
@@ -225,7 +225,7 @@ Fig 6.  Virtual Address Space with Statically Linked Libraries
 Because of this permanence, this process is referred to as static linking.  It has at least two significant disadvantages:
 <ul>
 	<li>Many libraries (e.g. libc) are used by almost every program on the system.  Thousands of identical copies of the same code increase the required down-load time, disk space (to store them), start-up time (to read them into memory) and memory (while they are executing).  It would be much more efficient if we could somehow allow all of the programs that used a popular library to share a single copy.</li>
-	<li>Popular libraries change over time with enhancements, optimizations, and bug fixes.   Some enhancements may be very important (e.g. enabling applications to work with a new version of the operating system).   In most cases, a newer version of a library is probably better than an older version.  But with static linking, each program is built with a frozen version of each library, as it was at the time the program was linkage edited.  It might be better (for software reliability) if it was possible to automatically load the latest library versions each time a program was started.</li>
+	<li>Popular libraries change over time with enhancements, optimizations, and bug fixes.  Some enhancements may be very important (e.g. enabling applications to work with a new version of the operating system).  In most cases, a newer version of a library is probably better than an older version.  But with static linking, each program is built with a frozen version of each library, as it was at the time the program was linkage edited.  It might be better (for software reliability) if it was possible to automatically load the latest library versions each time a program was started.</li>
 </ul>
 </p>
 <p>

--- a/principles.html
+++ b/principles.html
@@ -30,7 +30,7 @@ We need tools and techniques to tame this complexity.  Without such tools, we
 cannot deliver today's software ... much less tomorrow's.
 </P>
 <P>
-Operating Systems have long been among the largest and complex pieces of 
+Operating systems have long been among the largest and complex pieces of 
 software: 
 <ul>
    <li>	They involve complex interactions among many sub-systems.</li>
@@ -129,7 +129,7 @@ We must also require that:
    <li> Each group/component (at each level) have a coherent purpose.</li>
    <li> Most functions (for which a particular group is responsible) can be performed entirely
         within that group/component.</li>
-   <li> The union of the groups/component (within each super-group/system) is able to achieve the system's  purpose.</li>
+   <li> The union of the groups/component (within each super-group/system) is able to achieve the system's purpose.</li>
 </ul>
 These requirements are the difference between an arbitrary decomposition and a hierarchical decomposition.
 Such a decomposition makes it possible to opaquely encapsulate the internal operation of a sub-group/component, 
@@ -180,7 +180,7 @@ We can go a little further in defining the characteristics of good modularity:
        <ul>
           <li>the overhead of communication between components may reduce system efficiency.</li>
 	  <li>the increased number of interfaces to service those inter-component requests
-	      increases the complexity of the system and the opportunity for mis-understandings.</li>
+	      increases the complexity of the system and the opportunity for misunderstandings.</li>
           <li>increased dependencies between components increase the likelihood of
 	      errors or misunderstandings.</li>
        </ul>
@@ -570,7 +570,7 @@ to system performance and robustness.
 Life is made up of huge projects involving a myriad of complex, parallel activities 
 among numerous independent agents (e.g. growing up, getting and education, getting
 married, finding and keeping a job, raising children, ...).  
-Thus it should not be surprising if many of the lessons we learn from Operating Systems 
+Thus it should not be surprising if many of the lessons we learn from operating systems 
 turn out to be applicable to many other aspects of our lives (and vice versa).
 </p>
 
@@ -582,7 +582,7 @@ There are common situations with simple and obvious solutions,
 but those solutions don't correctly handle all situations.
 We often have multiple conflicting goals, and an approach 
 that optimizes one goal usually compromises another.
-There is almost always a down-side.
+There is almost always a downside.
 </P>
 <P>
 Any solution we formulate is likely to involve costs, trade-offs and compromises.
@@ -726,13 +726,13 @@ OS designers are not, by nature, optimists.
 <H2>5. Conclusions</h2>
 <P>
 Despite the fact that Operating Systems encompass ever more responsibility,
-relatively few people will actually build Operating Systems software.
+relatively few people will actually build operating systems software.
 But most of us will work on complex software, and we will encounter problems
 that have already been encountered, understood, and solved by computer scientists,
 architects, and developers in the field of Operating Systems.
 </P>
 <P>
-As you read about various mechanisms and issues within Operating Systems,
+As you read about various mechanisms and issues within operating systems,
 study them with these principles in mind.  As we analyze implications
 and contrast alternatives, try to pull these principles into the discussion
 and see if they shed light on the problems.

--- a/realtime.html
+++ b/realtime.html
@@ -80,7 +80,7 @@ may have a few characteristics that make scheduling easier:
    <LI>We may actually know how long each task will take to run.
        This enables much more intelligent scheduling.</li>
    <li><em>Starvation</em> (of low priority tasks) may be acceptable.
-       The space shuttle  absolutely must sense attitude and acceleration and adjust
+       The space shuttle absolutely must sense attitude and acceleration and adjust
        spolier positions once per millisecond.  But it probably doesn't
        matter if we update the navigational display once per millisecond
        or once every ten seconds.  Telemetry transmission is probably

--- a/stability.html
+++ b/stability.html
@@ -161,7 +161,7 @@ If you are going to be delivering binary software to non-developers
 what ever platform they run it on will correctly implement all of
 the interfaces on which your program depends.
 <P>
-The same argument applies, tho not quite as strongly, to independent
+The same argument applies, though not quite as strongly, to independent
 components in a single system.  If components exchange services, and
 I make an incompatible change to the interfaces of one component, this
 has the potential to break other components in the same system.  I can
@@ -169,7 +169,7 @@ fix the other components in our system to work with the new changes
 but:
 <UL>
    <LI> this complicates the making of the change.
-   <LI> we have to ensure that mis-matched component sets are impossible.
+   <LI> we have to ensure that mismatched component sets are impossible.
 </UL>
 <P>
 <H2>Is every interface carved in stone?</H2>
@@ -181,8 +181,8 @@ specification (a faster or more robust implementation).  In
 many cases you can add upwards-compatible extensions (all old
 programs will still work the same way, but new interfaces enable
 new software to access new functionality).  There are a few
-ways to add incompatable changes to old interfaces without
-breaking <em>backwards compatability</em>:
+ways to add incompatible changes to old interfaces without
+breaking <em>backwards compatibility</em>:
 <UL>
 <DL>
 <DT><strong>Interface Polymorphism</strong></DT>
@@ -195,12 +195,12 @@ breaking <em>backwards compatability</em>:
 	(e.g. by the number and types of their parameters), it may be 
 	possible to provide new interfaces to meet new requirements,
 	while continuing to support the older interfaces for
-	backwards compatability with older applications.
+	backwards compatibility with older applications.
     </P></DD>
 <DT><strong>Versioned Interfaces</strong></DT>
     <DD><P>
-	Backwards comptability requirements do not prevent us from
-	changing interfaces; They merely require us to continue
+	Backwards comptibility requirements do not prevent us from
+	changing interfaces; they merely require us to continue
 	providing old interfaces to old clients.
 	In many cases, it may be possible for an application to call
 	out which version of an interface it requires:

--- a/usermodethreads.html
+++ b/usermodethreads.html
@@ -138,4 +138,4 @@ implementation that uses an atomic instruction to attempt to get a
 lock, but calls the operating system if that allocation fails
 (somewhat like the <em>futex(7)</em> approach).
 </body>
-<html>
+</html>

--- a/usermodethreads.html
+++ b/usermodethreads.html
@@ -25,7 +25,7 @@ The answer to these needs was to create threads.  A thread ...
    <li>has its own stack (within the owning process' address space).</li>
 </ul>
 <P>
-Threads were added to Unix/Linux as an after-thought. In Unix, a process
+Threads were added to Unix/Linux as an afterthought. In Unix, a process
 could be scheduled for execution, and could create threads for
 additional parallelism.
 Windows NT is a newer operating system, and it was designed

--- a/workingsets.html
+++ b/workingsets.html
@@ -51,7 +51,7 @@ will make poor decisions.  Global LRU and Round-Robin scheduling
 are great algorithms, but they do not work well as a team.
 It might make sense to give each process its own
 dedicated set of page frames.  When that process needed a new
-page, we would LRU replace the oldest page in that set.
+page, we would let LRU replace the oldest page in that set.
 This would be <em>per-process</em> LRU, and that might work 
 very well with Round-Robin scheduling.
 </P>
@@ -141,7 +141,7 @@ throughput (efficiency).
 <h2>Implementing Working Set replacement</h2>
 <P>
 Regularly scanning all of memory to identify the least recently used
-page is a very expensive process.  With global LRU, we saw that a 
+page is a very expensive process.  With Global LRU, we saw that a 
 clock-like scan was a very inexpensive way to achieve a very 
 similar affect.  The clock hand position was a surrogate for age:
 </P>


### PR DESCRIPTION
I noticed some spelling mistakes and inconsistencies (e.g. "de-fragmentation" and "defragmentation" within the same file; or "Operating Systems" and "operating systems" within the same file regarding the actual system, not the course or the field, which I left capitalized).