### PR TITLE
Fix misspellings in various files

### DIFF
--- a/BSD/bsd.html
+++ b/BSD/bsd.html
@@ -100,7 +100,7 @@ Like most UNIX-derived file systems, BSD file systems:
 </UL>
 <P>
 In a classic UNIX file system (UFS) the file descriptors (I-nodes)
-all appear near the begining of the volume, with the data blocks
+all appear near the beginning of the volume, with the data blocks
 after them.  Disk activity instrumentation showed that the disk
 spent a great deal of time seeking back-and forth between the I-node
 area and the data blocks.  This led to one of the most significant
@@ -120,7 +120,7 @@ can be opened and read with minimal head motion.
 The mini-file systems are not truly independent.  A directory in one cylinder
 group can refer to an I-node in another cylinder group, and an I-node can
 point to blocks on any cylinder group.  When this happens, however, the
-system incurrs additional head motion when processing those files, and
+system incurs additional head motion when processing those files, and
 I/O performance is reduced.
 
 <H4>3. Volume Descriptor (Super Block)</h4>
@@ -134,7 +134,7 @@ a severely damaged file system.
 <P>
 The primary superblock can be found in the second block (block 1) of
 the volume.  Realize, however, that file systems can support a wide
-range of bolck sizes ... so the superblock may be 512 bytes into the
+range of block sizes ... so the superblock may be 512 bytes into the
 volume, or it may be 64K bytes into the volume (depending on what the
 file system block size is).  When opening a new file system, the OS
 may have to probe multiple locations in order to find the superblock
@@ -166,7 +166,7 @@ its contents is).
 <H4>3.2 File System Layout Parameters</h4>
 <P>
 In order to interpret the bits of any UNIX file system, we need
-to know how the file system is layed out.  Because they are divided
+to know how the file system is laid out.  Because they are divided
 into cylinder groups, BSD file systems have many more layout 
 parameters than most file systems:
 <P>
@@ -210,9 +210,9 @@ files.
 <P>
 <H4>3.4 File System Tuning Parameters</h4>
 <P>
-We are often forced to make trade-offs between how rappidly we can
+We are often forced to make trade-offs between how rapidly we can
 perform various operations, and how efficiently we use space.  BSD
-file systems have per file system tuning paremeters that permit
+file systems have per file system tuning parameters that permit
 system managers to make different trade-offs on different file
 systems.  A temporary file system, for instance, might be optimized
 for allocation speed, while a project archival file system might
@@ -274,7 +274,7 @@ same administrative information in their I-nodes:
 		access, for the owning user, the owning group,
 		and anyone else.
 	<LI> The integer user-ID of the user who owns the file.
-	<LI> The ingeger group-ID of the group who owns the file.
+	<LI> The integer group-ID of the group who owns the file.
 	<LI> The time when the file was last accessed.
 	<LI> The time when the file was last modified.
 	<LI> The time when the I-node was last updated.
@@ -471,7 +471,7 @@ can contain pointers to files on other file systems, whose contents
 may change in ways that later invalidate the symbolic links.
 <P>
 Detecting loops in paths that span multiple file systems and 
-machines is both dificult and expensive.  When the Berkeley team
+machines is both difficult and expensive.  When the Berkeley team
 added symbolic links to UNIX, they added a very simple feature
 that counts the number of I-node fetches associated with a single
 open ... and if that number gets too big (e.g. greater than 100)
@@ -498,7 +498,7 @@ studying BSD file systems:
 	<strong>symbolic</strong> links.
    <LI>
 	that sometimes, it may be acceptable to make non-upwards
-	compatable changes ... but not very often, and they have 
+	compatible changes ... but not very often, and they have 
 	to be made in a way that programmers will be willing to
 	adopt (e.g. using a more general mechanism to walk 
 	directory trees).
@@ -508,7 +508,7 @@ The functionality requirements that motivated the BSD changes are
 common.  The functionality, performance, and robustness supported 
 by BSD file systems is often considered the base-line against which 
 other file systems are judged.  The decision about whether or not
-new features justify non-upwards compaible extensions is one that
+new features justify non-upwards compatible extensions is one that
 most OS vendors have had to face.
 
 <H4>8. References</h4>

--- a/BSD/ext3.html
+++ b/BSD/ext3.html
@@ -65,7 +65,7 @@ Like most UNIX-derived file systems, EXT3 file systems:
 </UL>
 <P>
 In a classic UNIX file system (UFS) the file descriptors (I-nodes)
-all appear near the begining of the volume, with the data blocks
+all appear near the beginning of the volume, with the data blocks
 after them.  Disk activity instrumentation showed that the disk
 spent a great deal of time seeking back-and forth between the I-node
 area and the data blocks.  This led to one of the most significant
@@ -85,7 +85,7 @@ can be opened and read with minimal head motion.
 The mini-file systems are not truly independent.  A directory in one cylinder
 group can refer to an I-node in another cylinder group, and an I-node can
 point to blocks on any cylinder group.  When this happens, however, the
-system incurrs additional head motion when processing those files, and
+system incurs additional head motion when processing those files, and
 I/O performance is reduced.
 
 <H4>3. Volume Descriptor (Super Block)</h4>
@@ -99,7 +99,7 @@ a severely damaged file system.
 <P>
 The primary superblock can be found in the second block (block 1) of
 the volume.  Realize, however, that file systems can support a wide
-range of bolck sizes ... so the superblock may be 512 bytes into the
+range of block sizes ... so the superblock may be 512 bytes into the
 volume, or it may be 64K bytes into the volume (depending on what the
 file system block size is).  When opening a new file system, the OS
 may have to probe multiple locations in order to find the superblock
@@ -131,7 +131,7 @@ its contents is).
 <H4>3.2 File System Layout Parameters</h4>
 <P>
 In order to interpret the bits of any UNIX file system, we need
-to know how the file system is layed out.  Because they are divided
+to know how the file system is laid out.  Because they are divided
 into cylinder groups, BSD file systems have many more layout 
 parameters than most file systems:
 <P>
@@ -177,7 +177,7 @@ files.
 <P>
 We are often forced to make trade-offs between how rapidly we can
 perform various operations, and how efficiently we use space.  BSD
-file systems have per file system tuning paremeters that permit
+file systems have per file system tuning parameters that permit
 system managers to make different trade-offs on different file
 systems.  A temporary file system, for instance, might be optimized
 for allocation speed, while a project archival file system might
@@ -239,7 +239,7 @@ same administrative information in their I-nodes:
 		access, for the owning user, the owning group,
 		and anyone else.
 	<LI> The integer user-ID of the user who owns the file.
-	<LI> The ingeger group-ID of the group who owns the file.
+	<LI> The integer group-ID of the group who owns the file.
 	<LI> The time when the file was last accessed.
 	<LI> The time when the file was last modified.
 	<LI> The time when the I-node was last updated.
@@ -435,7 +435,7 @@ can contain pointers to files on other file systems, whose contents
 may change in ways that later invalidate the symbolic links.
 <P>
 Detecting loops in paths that span multiple file systems and 
-machines is both dificult and expensive.  When the Berkeley team
+machines is both difficult and expensive.  When the Berkeley team
 added symbolic links to UNIX, they added a very simple feature
 that counts the number of I-node fetches associated with a single
 open ... and if that number gets too big (e.g. greater than 100)
@@ -462,7 +462,7 @@ studying BSD file systems:
 	<strong>symbolic</strong> links.
    <LI>
 	that sometimes, it may be acceptable to make non-upwards
-	compatable changes ... but not very often, and they have 
+	compatible changes ... but not very often, and they have 
 	to be made in a way that programmers will be willing to
 	adopt (e.g. using a more general mechanism to walk 
 	directory trees).
@@ -472,7 +472,7 @@ The functionality requirements that motivated the BSD changes are
 common.  The functionality, performance, and robustness supported 
 by BSD file systems is often considered the base-line against which 
 other file systems are judged.  The decision about whether or not
-new features justify non-upwards compaible extensions is one that
+new features justify non-upwards compatible extensions is one that
 most OS vendors have had to face.
 
 <H4>8. References</h4>

--- a/BSD/oldunix.html
+++ b/BSD/oldunix.html
@@ -359,7 +359,7 @@ and written very efficiently.
 In memory allocation, we found that variable partition allocation 
 almost inevitably led to external fragmentation.  Over short 
 periods, coalescing can counter this trend ... but ultimately
-external framgentation is likely to win.  The same thing is true
+external fragmentation is likely to win.  The same thing is true
 of MVS volumes.  For this reason, MVS data administrators have
 to back-up and rebuild their file systems occasionally ... to
 reallocate space more efficiently, and coalesce all of the 

--- a/DOS/dos.html
+++ b/DOS/dos.html
@@ -107,7 +107,7 @@ disks and (unpartitioned) floppies, and between various releases
 of DOS and Windows ... but conceptually, the boot record:
 <UL>
 	<LI> begins with a branch instruction 
-		(to the start of the real boostrap code).
+		(to the start of the real bootstrap code).
 	<LI> followed by a volume description (BIOS Parameter Block)
 	<LI> followed by the real bootstrap code
 	<LI> followed by an optional disk partitioning table
@@ -130,7 +130,7 @@ It describes the device geometry:
 		<LI> number of tracks per cylinder
 		<LI> total number of sectors on the volume
 	</UL>
-It also describes the way the file system is layed out on the volume:
+It also describes the way the file system is laid out on the volume:
 	<ul>
 		<LI> number of sectors per (logical) cluster
 		<LI> the number of reserved sectors (not part of file system)
@@ -355,7 +355,7 @@ file.
 <P>
 The "next block" organization of the FAT means that
 in order to figure out what physical cluster is the third logical
-block of ar file, must know the physical cluster number of the second
+block of a file, must know the physical cluster number of the second
 logical block.
 This is not usually a problem, because almost all file access is
 sequential (reading the first block, and then the second, and then 
@@ -376,7 +376,7 @@ The notion of "next block" is only meaningful for clusters that
 are allocated to a file ... which leaves us free to use the
 FAT entries associated with free clusters as a free indication.
 Just as we reserved a value (-1) to mean <strong>end of file</strong>
-we can rerserve another value (0) to mean
+we can reserve another value (0) to mean
 <strong>this cluster is free</strong>.
 <P>
 To find a free cluster, one has but to search the FAT for an
@@ -410,12 +410,12 @@ file was free, and marked them as such in the File Allocation Table.
 This "feature" was probably motivated by a combination of laziness
 and a desire for performance.  It did, however, have an advantage.
 Since clusters were not freed when files were deleted, they could not
-be reallocated until after garbage colection was performed.  This
+be reallocated until after garbage collection was performed.  This
 meant that it might be possible to recover the contents of deleted
 files for quite a while.  The opportunity this created was large 
 enough to enable Peter Norton to start a very successful company.
 <P>
-<H4>6. Descendents of the DOS file system</H4>
+<H4>6. Descendants of the DOS file system</H4>
 <P>
 The DOS file system has evolved with time.  Not only have wider 
 (16- and 32-bit) FAT entries been used to support larger disks,
@@ -446,7 +446,7 @@ The solution they came up was to put the extended filenames in
 additional (auxiliary) directory entries.  Each file would be
 described by an old-format directory entry, but supplementary
 directory entries (following the primary directory entry) could 
-provide extenstions to the file name.  
+provide extensions to the file name.  
 To keep older systems from being confused by the new directory
 entries, they were tagged with a very unusual set of attributes
 (hidden, system, read-only, volume label).  Older systems 
@@ -461,7 +461,7 @@ able to access files by either the long or the short names.
 <P>
 The addition of long file names did create one problem for
 the old directory entries.  What would you do if you had two
-file names that differred only after the 8th character (e.g.
+file names that differed only after the 8th character (e.g.
 datafileread.c and datafilewrite.c)?  If we just used the
 first 8 characters of the file name in the old directory
 entries (datafile), we would have two files with the same
@@ -483,7 +483,7 @@ Events that corrupt the File Allocation Table are extremely
 rare, but the consequences of such an incident are catastrophic.
 To protect users from such eventualities, MicroSoft added support
 for alternate FATs.  Periodically, the primary FAT would be copied
-to one of the pre-reserved alternat FAT locations.  Then if something
+to one of the pre-reserved alternate FAT locations.  Then if something
 bad happened to the primary FAT, it would still be possible to read
 most files (files created before the copy) by using the back-up FAT.
 This is an imperfect solution, as losing new files is bad ... but
@@ -501,13 +501,13 @@ a standard.
 The failings of the DOS file system were widely known by this time,
 but, as the most widely used file system on the planet, the committee
 members could not ignore it.  Upon examination, it became clear that
-the most ideomatic features of the DOS file system (the File Allocation
-Table) were irrelevent to a CDROM file system (which is written only
+the most idiomatic features of the DOS file system (the File Allocation
+Table) were irrelevant to a CDROM file system (which is written only
 once):
 <UL>
 	<LI> We don't need to keep track of the free space on a 
 	     CD ROM.  We write each file contiguously, and the
-	     next file goes immidiately after the last one.
+	     next file goes immediately after the last one.
 	<LI> Because files can be written contiguously, we don't
 	     need any "next block" pointers.  All we need to know
 	     about a file is where its first block resides.
@@ -542,7 +542,7 @@ They did, however, learn from DOS's mistakes:
    <LI>
 	Recognizing that, over time, people would want to associate
 	a wide range of attributes with files, they also created
-	a variable length extened attributes section after the
+	a variable length extended attributes section after the
 	file name.  Much of this section has been left unused,
 	but they defined several new attributes for files:
 	<UL>
@@ -574,7 +574,7 @@ widely used file system format on the planet.  Despite their
 primitiveness, DOS file systems were used as the basis for much
 newer CD ROM file system designs.
 <P>
-What can we infer from this?  That most users don't need alot of
+What can we infer from this?  That most users don't need a lot of
 fancy features, and that the DOS file system (primitive as it
 may be) covers their needs pretty well.  
 <P>
@@ -584,7 +584,7 @@ case file name limitations, they chose to do so with a kludgy
 (but upwards compatible) solution using additional directory
 entries per file.  The fact that they chose such an implementation
 clearly illustrates the importance of maintaining media 
-interchangability with older systems.  This too is a problem
+interchangeability with older systems.  This too is a problem
 that all (successful) file systems will eventually face.
 <P>
 
@@ -612,7 +612,7 @@ FDISK table format</A>.
 9660 file system information
 <UL>
     <LI>
-	WIkipedia Introduction to
+	Wikipedia Introduction to
 	<A Href=http://en.wikipedia.org/wiki/ISO_9660>
 	ISO 9660 file systems</A>
     <LI>

--- a/DOS/dosfiles.html
+++ b/DOS/dosfiles.html
@@ -109,7 +109,7 @@ Logical sector number 0 is sector 1 in track 0 on side 0.  Since this sector
 can always be located without knowing the disk structure, it is often used to
 store information about the disk structure. This is important for floppy
 disks, which are removable.  Many floppy disk drives can accommodate disks
-with more than one format.  The file system codecan read logical sector 0 to
+with more than one format.  The file system code can read logical sector 0 to
 find out how to locate other sectors.
 <P>
 As the logical sector number increases, the heads must be moved only when the
@@ -465,14 +465,14 @@ The very first byte of a directory entry has another function.  If it is
 hexadecimal E5, the entry represents a deleted file, subdirectory or volume
 label.  All other parts of the entry are valid and represent the status of the
 entry just before it was deleted.  If the first byte is zero (not an ASCII
-zero, which has the value hexdecimal 30, but an ASCII NUL), the entry is a
+zero, which has the value hexadecimal 30, but an ASCII NUL), the entry is a
 terminating entry.  It has never been used since the directory was created,
 and there are no entries after it in the same directory.
 <P>
 When DOS 3.0 came along, characters from the IBM extended character set were
 permitted in file names and extensions.  Unfortunately, this created an
 ambiguity for hexadecimal E5, which represents an IBM extended character and
-also represents a deleted entry.  For compatiblity between DOS 3.0 and disks
+also represents a deleted entry.  For compatibility between DOS 3.0 and disks
 formatted under previous versions of DOS, DOS 3.0 converts the extended
 character represented by hexadecimal E5 into 05 before writing it to the
 directory entry when it appears as the first character of a file name.
@@ -522,7 +522,7 @@ with the same name and extension as an existing file in the same directory,
 and the file mode permits, the new entry will simply replace the old one.  A
 new volume label in the root directory simply replaces the old one, if any.
 <P>
-When an entry is deleted, its first byte is replaced by hexedecimal E5 to mark
+When an entry is deleted, its first byte is replaced by hexadecimal E5 to mark
 it as deleted.  The rest of the entry is left unchanged.  If the entry
 represented a file or subdirectory, all clusters associated with it are marked
 as empty in the file allocation table.  The data in the clusters is not

--- a/KERBEROS/kerberos.html
+++ b/KERBEROS/kerberos.html
@@ -1,7 +1,7 @@
 <TITLE>Kerberos: An Authentication Service for Computer Networks</TITLE>
 
 <H3>USC/ISI Technical Report number ISI/RS-94-399</H3>
-Copyright © 1994 Institute of Electrical and Electronics Engineers.<BR>
+Copyright ï¿½ 1994 Institute of Electrical and Electronics Engineers.<BR>
 Reprinted, with permission, from IEEE Communications Magazine,<BR>
 Volume 32, Number 9, pages 33-38, September 1994.<BR>
 Click <A
@@ -108,7 +108,7 @@ themselves simply assertions.
 <P>
 
 Stronger authentication methods base on cryptography are required.
-When using authentication based on crytography, an attacker listening
+When using authentication based on cryptography, an attacker listening
 to the network gains no information that would enable it to falsely
 claim another's identity.  Kerberos is the most commonly used example
 of this type of authentication technology.  Unfortunately, strong
@@ -386,7 +386,7 @@ data that is transmitted.
 The description of Kerberos just presented was greatly simplified.
 Additional fields are present in the ticket, authenticator, and
 messages, to support book-keeping and additional functionality.  Some
-of the features present in Vesion 5 include renewable and forwardable
+of the features present in Version 5 include renewable and forwardable
 tickets, support for higher level authorization mechanisms, and
 support for multi-hop cross-realm authentication (described in the
 following section).  A more rigorous presentation of the Kerberos

--- a/MVS/mvs.html
+++ b/MVS/mvs.html
@@ -353,7 +353,7 @@ and written very efficiently.
 In memory allocation, we found that variable partition allocation 
 almost inevitably led to external fragmentation.  Over short 
 periods, coalescing can counter this trend ... but ultimately
-external framgentation is likely to win.  The same thing is true
+external fragmentation is likely to win.  The same thing is true
 of MVS volumes.  For this reason, MVS data administrators have
 to back-up and rebuild their file systems occasionally ... to
 reallocate space more efficiently, and coalesce all of the 

--- a/authservers.html
+++ b/authservers.html
@@ -45,7 +45,7 @@ technique to get trusted <em>capabilities</em>:
    <li> after a successful access check, the authentication 
    	server would create a <em>work ticket</em> describing
 	the actor, the permitted operation, and any other
-	relevent information (e.g. "good until date"), and
+	relevant information (e.g. "good until date"), and
 	then sign it (e.g. with his private key)</li>
    <li>	the actor would present the <em>work ticket</em> to
    	the appropriate server along with the request.</li>

--- a/avoidance.html
+++ b/avoidance.html
@@ -76,8 +76,8 @@ Unlike <em>malloc(3)</em>, these other operations do not tell
 us how much new resource the process wants to consume.  But
 in each of these cases there is a request (to which we can 
 return an error) before we reach actual resource exhaustion.
-And it is this failable request that gives us the opporutunity to 
-consider, and avoid a resouce-exhaustion deadlock.
+And it is this failable request that gives us the opportunity to
+consider, and avoid a resource-exhaustion deadlock.
 </P>
 <H2>Over-Booking</H2>
 <P>
@@ -111,8 +111,8 @@ What should a process do when some resource allocation request
 <ul>
 	<li> A simple program might log an error message and exit.</li>
 	<li> A stubborn program might continue retrying the request
-	    (in hope tht the problem is transient).</li>
-	<li>A more robust program might return errors for requsts that cannot
+	    (in hope that the problem is transient).</li>
+	<li>A more robust program might return errors for requests that cannot
 	be processed (for want of resources), but continue trying to serve
 	new requests (in the hope that the problem is transient).</li>
 	<li>A more civic-minded program might attempt to reduce its 

--- a/clusterconcepts.html
+++ b/clusterconcepts.html
@@ -50,7 +50,7 @@ In most clusters, a node has to be explicitly configured or
 provisioned into the cluster ... so that the set of potential
 members is well known, and perhaps even closed to new members.
 There are, however, some types of clusters where any node is
-welcooe to join at any time.
+welcome to join at any time.
 
 <H2>Degree of Coupling</H2>
 <P>
@@ -103,7 +103,7 @@ tell that they are not all running on a single computer.
 <P>
 In a clustered system, work is divided among the active members.
 To reduce distributed synchronization, it is common to <em>partition</em>
-the work (e.g. desigate each server responsible for a certain
+the work (e.g. designate each server responsible for a certain
 subset (e.g. a file system, a range of keys, etc) of requests, 
 and route all requests to their designated owner).  
 In such systems, we can talk about <em>primaries</em>
@@ -128,10 +128,10 @@ availability:
 </P>
 <P>
 An active/active architecture achieves better resource utilization, and so
-may be more cost-effective.  But when a failure occurrs, the load on the
+may be more cost-effective.  But when a failure occurs, the load on the
 surviving nodes is increased and so performance may suffer.
 An active/stand-by architecture normally has idle capacity, but may not suffer
-any performance degradataion after a failure.
+any performance degradation after a failure.
 </P>
 <P>
 We can also look at how quickly a successor is able to take over a 
@@ -159,7 +159,7 @@ cluster, or are about to leave it.  This is not always the case:
 <P>
 Since we cannot be sure that member will notify the other members before
 he leaves the cluster, we need a means of detecting a member who has
-dropped unexpectedly out of the cluster.  The most common techique is
+dropped unexpectedly out of the cluster.  The most common technique is
 called a "heart beat".  A heart beat is a message, regularly exchanged
 between cluster members.  These may be special messages, or they may
 be piggy-backed on other traffic. If too much time passes without our having
@@ -182,7 +182,7 @@ master:
    <LI> Coming to a mutual agreement between multiple nodes can be
 	a complex process (e.g. Three Phase Commits).  If one node
 	is designated a cluster master, that node can serve as a
-	central point of syncrhronization and/or control for operations
+	central point of synchronization and/or control for operations
 	in the cluster.</li>
    <LI> Rather than requiring all nodes to heart-beat one-another,
 	it is more economical to simply have all nodes heart-beat
@@ -192,7 +192,7 @@ master:
 <P>
 The election of a cluster master may, itself, be a complex process ...
 but having performed that process may eliminate the need for any
-further negotiations.  There are numerous well established election/concensus
+further negotiations.  There are numerous well established election/consensus
 algorithms.  One of the best known is Leslie Lamport's 
 <A Href=http://en.wikipedia.org/wiki/Paxos_algorithm>Paxos algorithm</A>.
 
@@ -217,7 +217,7 @@ There are two standard approaches to preventing "split-brain":
 <P>
 If there are N potential members in a cluster, we can build in a rule
 that says a cluster cannot form with fewer than (N/2)+1 members.  This
-acomplishes two purposes:
+accomplishes two purposes:
 <UL>
    <LI> It makes it impossible for any partitioning to result in two
 	viable sub-clusters (because N nodes cannot be divided into two
@@ -253,7 +253,7 @@ formed by a single node ... because the voting device would prevent split-brain.
 
 <H2>Fencing</h2>
 <P>
-What if, you were not only sufferring from schizophrenia, but the other
+What if, you were not only suffering from schizophrenia, but the other
 side of your brain had actually gone rogue, and was trying to commit acts
 of mayhem against you and others?
 In some clustered systems, it must be assumed that if a node has fallen

--- a/distsystems.html
+++ b/distsystems.html
@@ -243,7 +243,7 @@ that would never happen in a single (homogeneous) system.
 <h3>Emergent phenomena</h3>
 <P>
 The human mind renders complex systems understandable by 
-contructing simpler abstract models.  But simple models
+constructing simpler abstract models.  But simple models
 (almost by definition) cannot fully capture the behavior of
 a complex system.
 Complex systems often exhibit <em>emergent behaviors</em> that were
@@ -272,7 +272,7 @@ He enumerated them in an often cited paper:
    <DT>4. The network is secure.</DT>
    	<DD>While not perfect, operating systems are sufficiently well protected that we (relatively) seldom have
 	    to worry about malicious attacks within our own computer.  Once we put a computer on a network it
-	    becomes susceptable to penetration attempts, man-in-the-middle attacks, and denial-of-service attacks.</DD>
+	    becomes susceptible to penetration attempts, man-in-the-middle attacks, and denial-of-service attacks.</DD>
    <DT>5. Topology does not change.</DT>
    	<DD>In a distributed system, routes change and new clients/servers appear and disappear continuously.
 	    Distributed applications must be able to deal with an ever-changing set of connections to an

--- a/driverclasses.html
+++ b/driverclasses.html
@@ -18,7 +18,7 @@ Device drivers represent both:
    	</p>
    <dt>simplifying abstractions</dt>
 	<P>
-	<dd>	providing an implemention of standard class interfaces
+	<dd>	providing an implementation of standard class interfaces
 		while opaquely encapsulating the details of how to
 		effectively and efficiently use a particular
 		device.</dd>
@@ -28,7 +28,7 @@ Device drivers represent both:
 <P>
 For reasons of performance and control, Operating Systems tend not to be 
 implemented in object oriented languages (does anybody remember JavaOS?).
-Yet despite being implemented in simpler langauges (often C), Operating
+Yet despite being implemented in simpler languages (often C), Operating
 Systems, in device drivers, offer highly evolved examples of a different
 realization of class interfaces, derivation, and inheritance.
 </P>
@@ -45,7 +45,7 @@ of these devices creates tremendous demands for object oriented code reuse:
    <li> We would like to minimize the cost of developing drivers
     	to support new devices.  This is most easily done if the
 	majority of the functionality is implemented in common
-	code that can be inherrited by the individual drivers.</li>
+	code that can be inherited by the individual drivers.</li>
    <li> As system functionality and performance are improved, we
    	would like to ensure that those benefits accrue not only
 	to new device drivers, but also to older device drivers.</li>
@@ -164,7 +164,7 @@ Unix.  But as system functionality evolved, the operating system
 began to implement higher level services for other sub-classes of
 devices:
 <UL>
-   <li> input editing and outut translation for terminals and virtual terminals</li>
+   <li> input editing and output translation for terminals and virtual terminals</li>
    <li> address binding and packet sending/receipt for network interfaces</li>
    <li> display mapping and window management for graphics adaptors</li>
    <li> character-set mapping for keyboards</li>
@@ -236,7 +236,7 @@ for the DDI entry points.  If an operating system eliminates or incompatibly
 changes a DKI function, device drivers that depend on that function may
 cease working.  The requirement to maintain stable DKI entry points may 
 greatly constrain our ability to evolve our operating system implementation.
-Similar issues arrise for other classes of dynamically loadable kernel
+Similar issues arise for other classes of dynamically loadable kernel
 modules (such as network protocols and file systems).
 </p>
 <h2>Conclusion</h2>
@@ -244,7 +244,7 @@ modules (such as network protocols and file systems).
 Device drivers demonstrate an evolution from a basic super-class (character
 devices) into an ever-expanding hierarchy of derived sub-classes.  But unlike
 traditional class derivation, where sub-class implementations inherit most of
-their implemntation from their parent, we see a different sort of inheritance.
+their implementation from their parent, we see a different sort of inheritance.
 While each new sub-class and instance is likely to be a new implementation,
 what they inherit is pre-existing higher level frameworks that do 
 do most of their work for them.

--- a/driverclasses.html
+++ b/driverclasses.html
@@ -198,7 +198,7 @@ The rewards for this structure are:
 	software.</li>
    <li> The system behaves identically over a wide range of different
    	devices.</li>
-   <li> Most functionality enhancements to will be in the higher
+   <li> Most functionality enhancements will be in the higher
    	level code, and so should automatically work on all devices
 	within that sub-class.</li>
 </ul>

--- a/dynamicmodules.html
+++ b/dynamicmodules.html
@@ -56,11 +56,11 @@ loadable:
 In the abstract, a program needs an implementation and calls a <em>Factory</em> to
 obtain it.  But how does the Factory know what implementation class to instantiate?
 <UL>
-   <li>	for a browser plugin, there might be a MIME-type assocated with the
+   <li>	for a browser plugin, there might be a MIME-type associated with the
    	data to be handled, and the browser can consult a registry to find
 	the plug-in associated with that MIME-type.  This is a very general
 	mechanism ... but it presumes that data is tagged with a type, and
-	that somebody is maintaining a tag-to-plugin registery.</li>
+	that somebody is maintaining a tag-to-plugin registry.</li>
    <li>	at the other extreme, the Factory could load all of the known
    	plug-ins and call a <em>probe</em> method in each to see which (if any)
 	of the plug-ins could identify the data and claim responsibility for
@@ -70,7 +70,7 @@ obtain it.  But how does the Factory know what implementation class to instantia
 <P>
 Long ago, dynamically loadable device drivers used the probing process, but 
 this was both unreliable (might incorrectly accept the wrong device) and
-dangerious (touching random registers in random devices).  Today most
+dangerous (touching random registers in random devices).  Today most
 I/O busses support self-identifying devices.  Each device has type,
 model, and even serial number information that can be queried in a 
 standard way (e.g. by <em>walking the configuration space</em>).  
@@ -124,7 +124,7 @@ For a dynamically loaded device driver, the initialization method might:
        and assign them to the devices to be managed.</li>
    <li>register all of the device instances it supports.
    	Part of this registration would involve providing a vector
-	(of pointers to standard device drvier entry points) that client
+	(of pointers to standard device driver entry points) that client
 	software could call in order to use these device instances.
    </li>
 </ul>
@@ -222,7 +222,7 @@ operating system.
 </P>
 <P>
 There is often a tension between the conflicting needs to support new
-hardware and software features while retaining compatability
+hardware and software features while retaining compatibility
 with old device drivers.
 </P>
 <H2>Hot-Pluggable Devices and Drivers</H2>

--- a/filetypes.html
+++ b/filetypes.html
@@ -12,9 +12,9 @@ all data sources and sinks as files.
 Files are most commonly discussed as byte streams or one-dimensional arrays,
 and this is a fair description of much of the file processing done by
 applications software.  But many of those byte-streams contain highly
-structured data (e.g. a load module, an MPEG-4 video or a datablase).
+structured data (e.g. a load module, an MPEG-4 video or a database).
 Some very interesting sources of data (e.g. directories and key-value stores),
-while serializable, are are not even indended to be processed as byte streams,
+while serializable, are are not even intended to be processed as byte streams,
 but with very different APIs.  Many files have interesting attributes beyond
 the data they contain.
 </p>
@@ -31,7 +31,7 @@ byte stream:
 <ul>
    <li> A text file is a byte stream, but when we 
 	process it we generally break it into lines 
-	(deliminted by <em>\n</em> or <em>\r\n</em>), and 
+	(delimited by <em>\n</em> or <em>\r\n</em>), and 
 	render it as characters (e.g. according to the 
 	ASCII or ISO 8859 character set).</li>
 
@@ -49,7 +49,7 @@ byte stream:
 
    <li> an MPEG stream is a sequence of audio, video,
    	frames, containing compressed (e.g.
-	Discrete Cosine Transoform) program information,
+	Discrete Cosine Transform) program information,
 	which require considerable processing in order
 	to reconstruct the encoded program.
 	</li>
@@ -99,7 +99,7 @@ There are a few approaches to <em>classing</em> files:
    <li> Another common approach (very popular with Unix-derived systems)
    	is a <em>magic number</em> at the start of the file.
 	Each type of file (or even file system) begins with a 
-	reserved and registed magic number that identifies the
+	reserved and registered magic number that identifies the
 	file's type.  For more information on this approach,
 	look at the 
 	<A href="http://man7.org/linux/man-pages/man1/file.1.html">file(1)</a> command.</li>
@@ -191,7 +191,7 @@ byte streams, but accessed with very different operations.
 With inter-process communications ports, we have something with
 a very different implementation, but that is accessed 
 (as a byte stream)
-with normal file I/O opeartions.
+with normal file I/O operations.
 </p>
 <h3>3.3. I/O Devices</h3>
 <P>

--- a/gc_defrag.html
+++ b/gc_defrag.html
@@ -40,7 +40,7 @@ a few reasons:
 How does an allocated resource come to be returned to the free pool?
 <ul>
     <li>With many resources, and in many programming languages, allocated resources are
-    	freed by an explict or implicit action on the client's part.  Example
+    	freed by an explicit or implicit action on the client's part.  Example
 	include:
 	<ul>
 		<li> calling <em>close(2)</em> on a file</li>
@@ -53,13 +53,13 @@ How does an allocated resource come to be returned to the free pool?
    </p>
    <li>If a resource is sharable by multiple concurrent clients (e.g. an
        open file or a shared memory segment), we cannot
-       free it simply becuase one client called close.
+       free it simply because one client called close.
        The resource manager (e.g. the operating system) may maintain a 
        active reference count for each resource:
        <ul>
        		<li> increment the reference count whenever a new 
 		     reference to the object is obtained.</li>
-		<li> decrement the reference count whenevever a
+		<li> decrement the reference count whenever a
 		     reference is released (e.g. by calling close).</li>
 		<li> automatically free the object when the reference
 		     count reaches zero.</li>
@@ -78,7 +78,7 @@ But these two approaches are not always practical:
 		track of when which resources are no longer needed can be a lot of work.  For
 		this reason, many languages (e.g. Lisp, Java, Python) do not require
 		programs to explicitly free some resources (e.g. memory).  This not only
-		reduces developer task loading, but it also eliminages a great many
+		reduces developer task loading, but it also eliminates a great many
 		bugs.</li>
 	<li> some resources (e.g. DHCP addresses) may never be explicitly freed,
 		and so must be automatically recycled after they have gone unused
@@ -99,7 +99,7 @@ explicit or reference count based freeing.  In such a system ...
 			<li>begin with a list of all of the resources that originally existed.</li>
 			<li>scan the process to find all resources that are still reachable.</li>
 			<li>each time a reachable resource is found, remove it from the original resource list.</li>
-			<li>at the end of the scan, anything that is still in the list of original resouces,
+			<li>at the end of the scan, anything that is still in the list of original resources,
 			    is no longer referenced by the process, and can be freed.</li>
 			<li>after freeing the unused resources, normal program operation can resume.</li>
 		</ol>
@@ -215,7 +215,7 @@ In neither of these examples is defragmentation a one-time process.  Internal fr
 In the first (flash management) example the process is (like progressive garbage collection) a continuous one.
 In older file systems (e.g. Windows FAT file systems), the process was more likely periodic; Once or twice a year 
 we take the file system down to run defragmentation, after which performance should be good for a few more months.
-But in some newer file systems (e.g. the B-TRee File System) defragmentation is also a continuously ongoing process.
+But in some newer file systems (e.g. the B-Tree File System) defragmentation is also a continuously ongoing process.
 </p>
 <h2>Conclusions</h2>
 <P>

--- a/horizontal.html
+++ b/horizontal.html
@@ -51,7 +51,7 @@ a few basic (and highly inter-related) goals:
    	and requiring little or no configuration.</li>
    <li> service protocols that are designed to minimize the potential
    	modes of failure and enable simple recoveries.</li>
-   <li> service protcols that are optimized for throughput (vs latency) 
+   <li> service protocols that are optimized for throughput (vs latency) 
    	over very large (e.g. continental) distances.</li>
    <li> service protocols that exploit the numerous optimizations 
    	(e.g. web cache servers) and other features that
@@ -66,7 +66,7 @@ systems.
 <H2>Horizontally Scalable Hardware Platforms</H2>
 <P>
 All services in horizontally scalable systems are exchanged via
-network messages.  A node in such a system is simpy a computer
+network messages.  A node in such a system is simply a computer
 that implements the specified protocols.  
 The <em>unit of deployment</em> in most horizontally scalable
 systems is the node;  When a new service or more capacity is
@@ -215,7 +215,7 @@ to a small group (e.g. 3) of servers.  Assigning multiple servers
 to each shard enables us to maintain data availability even if
 some servers fail.  Imposing a low cap on the number of servers
 involved in any particular transaction enables the protocols to
-scale to thousands of nodes with no degradataion in performance.
+scale to thousands of nodes with no degradation in performance.
 When we need to add capacity, we do not add more servers for a 
 particular shard; rather, we increase the number of shards into 
 which the name space is divided, and assign the new shards to
@@ -240,7 +240,7 @@ but it is very well aligned with horizontally scalable architectures:
    	abstract/logical and thin-provisioned.  Horizontally scaled
 	architectures are well suited to implementing and delivering
 	such services.</li>
-   <li> The flexibility to continously add, remove, and rebalance
+   <li> The flexibility to continuously add, remove, and rebalance
    	resources in a horizontally scalable system, makes it 
 	possible for a cloud service provider to easily accommodate
 	great fluctuations in demand.</li>

--- a/interfaces.html
+++ b/interfaces.html
@@ -46,7 +46,7 @@ and <em>killer applications</em>, the situation was reversed:
 If applications are to be readily ported to all platforms, all platforms must 
 support the same services.  This means that we need detailed specifications for 
 all services, and comprehensive compliance testing to ensure the correctness 
-and compatability of those implementations.
+and compatibility of those implementations.
 </P>
 <P>
 The other big change was in who the customers for computers and software were.  

--- a/inversion.html
+++ b/inversion.html
@@ -41,7 +41,7 @@ But there is another situation ...
    <li> which, once identified, can be easily, promptly 
    	and effectively corrected</li>
 </ul>
-This is worthy of study, both as practical problem that arrises in real systems, 
+This is worthy of study, both as practical problem that arises in real systems, 
 and as an example of the complexity of ensuring <em>Quality of Service</em>.
 
 <h2>2. Priority Inversion</h2>

--- a/ipc.html
+++ b/ipc.html
@@ -122,7 +122,7 @@ network protocols.
 <H2>General Network Connections</H2>
 <P>
 Most operating systems now provide a fairly standard set of network
-communications APIs.  The associated Linux APIs ar:
+communications APIs.  The associated Linux APIs are:
 <UL>
    <li><em>socket(2)</em> ... create an inter-process communication end-point
    	with an associated protocol and data model.
@@ -156,7 +156,7 @@ A few examples include:
 Using more general networking models enables processes to interact with
 services all over the world, but this adds considerable complexity:
 <UL>
-   <LI>Ensuring interoperability with software running under differerent
+   <LI>Ensuring interoperability with software running under different
        operating systems on computers with different instruction set architectures.</li>
    <LI>Dealing with the security issues associated with exchanging data and
        services with unknown systems over public networks.</li>
@@ -234,7 +234,7 @@ a message (announcing the completion) to the waiter.
 But what if there are megabytes of queued requests, and we want to 
 send a message to abort those queued requests?
 Data sent down a network connection is FIFO ... and one of the
-problems with FIFO schdeduling is the delays 
+problems with FIFO scheduling is the delays 
 waiting for the processing of earlier but longer messages.
 Occasionally, we would like to make it possible for an
 important message to go directly to front of the line.
@@ -242,7 +242,7 @@ important message to go directly to front of the line.
 <P>
 If the recipient was local, we might consider sending a
 signal that could invoke a registered handler, and flush
-(without processing) all of the bufferred data.  This
+(without processing) all of the buffered data.  This
 works because the signals travel over a different
 channel than the buffered data.  Such communication
 is often called <em>out-of-band</em>, because it
@@ -258,8 +258,8 @@ The server on the far end periodically polls the
 out-of-band channel before taking requests from the
 normal communications channel.  This adds a little
 overhead to the processing, but makes it possible
-to preempt queued operations.  The choosen polling
-interal represents a trade-off between added overhead
+to preempt queued operations.  The chosen polling
+interval represents a trade-off between added overhead
 (to check for out-of-band messages) and how long
 we might go (how much wasted work we might do)
 before noticing an out-of-band message.

--- a/linkage.html
+++ b/linkage.html
@@ -8,7 +8,7 @@
 </center>
 <h2>Introduction</h2>
 <P>
-Two fundamental questions that quickly arise in the implementation of an operationg system
+Two fundamental questions that quickly arise in the implementation of an operating system
 are:
 <ol type="1">
 	<li> what constitutes the state of a computation, and how can that state be
@@ -163,8 +163,8 @@ While these details can be ISA specific, we also observe that:
 		of the calling routines.  This is often done, because only
 		the calling routine knows how many parameters is actually
 		passed.</li>
-	<li>The clear deliniation of responsibilities between the 
-		caller and callee make it possible to have proceedures
+	<li>The clear delineation of responsibilities between the 
+		caller and callee make it possible to have procedures
 		written in one language (e.g. C) called by programs 
 		written in another language (e.g. FORTRAN).</li>
 </ul>
@@ -175,7 +175,7 @@ There is still, however, value in understanding each step of the above process,
 because the same basic steps (some, perhaps automated by hardware)
 can be seen in almost all linkage conventions.   After you have 
 understood one set of linkage conventions, you should have little
-trouble understanding outhers.
+trouble understanding others.
 </p>
 <p>
 It is also interesting to note how relatively simple it is to
@@ -199,7 +199,7 @@ The key differences between a procedure call and an interrupt/trap are:
 <UL>
 	<LI> a procedure call is requested by the running software, and the
 		calling software expects that, upon return, some function will
-		have been performed, and an approprate value returned.</li>
+		have been performed, and an appropriate value returned.</li>
 	<LI> because a procedure call is initiated by software, all
 		of the linkage conventions are under software control. 
 		Because interrupts and traps are initiated by the hardware,

--- a/monitoring.html
+++ b/monitoring.html
@@ -68,7 +68,7 @@ ways to do this:
 	 being responded to correctly and in a timely fashion.</li>
 </ul>
 <P>
-Any of these techiques could alert us of a potential deadlock,
+Any of these techniques could alert us of a potential deadlock,
 livelock, loop, or a wide range of other failures.  But each
 of these techniques has different strengths and weaknesses:
 <ul>
@@ -115,7 +115,7 @@ recovery, and fail-over:
    <li> The software should be designed so that any process
    	in the system can be killed and restarted at any time.
 	When a process restarts, it should be able to reestablish 
-	communiction with the other processes and resume working
+	communication with the other processes and resume working
 	with minimal disruption. </li>
     <li>The software should be designed to support multiple
         levels of restart. Examples might be:
@@ -157,7 +157,7 @@ perhaps:
    <li> the operation that caused process A to fail is still
    	listed in the database, and when process A restarts,
 	it may attempt to re-try the same operation and fail
-	agian.</li>
+	again.</li>
    <li> the operation that caused process A to fail may have
         been mirrored to other systems, that will also 
 	experience or cause additional failures.</li>

--- a/multiprocessor.html
+++ b/multiprocessor.html
@@ -50,7 +50,7 @@ But it is reasonable to ask whether or not 16x3B instructions per second is actu
 equivalent to 48B instructions per second?  The answer (see
 <A href=" https://en.m.wikipedia.org/wiki/Amdahl%27s_law">Amdahl's Law</A>)
 depends on whether or not your application can be divided into 16 or more 
-parallely executable sub-tasks.  Fortunately, modern operating systems tend
+parallelly executable sub-tasks.  Fortunately, modern operating systems tend
 to run large numbers of processes, and expensive computations are
 increasingly designed to be executable in multiple parallel threads..
 </P>
@@ -82,7 +82,7 @@ time-sharing at the micro-code level.  It is common for a pair of hyper-threads
 to get 1.2-1.8 times the instructions per second that a single thread would have gotten on
 the same core.  It is theoretically possible to get 2x hyper-threading, but a thread might
 run out of L1 cache for a long time without blocking, or perhaps both hyper-threads
-are bocked waiting for memory.
+are blocked waiting for memory.
 </P>
 <P>
 From a performance point-of-view, it is important to understand that both
@@ -292,7 +292,7 @@ cores handle which I/O operations:
    <li>	as with scheduling, sending all operations for a particular
 	device to a particular core may result in more L1/L2
 	cache hits and more efficient execution.</li>
-   <li>	syncrhonization between the synchronous (resulting
+   <li>	synchronization between the synchronous (resulting
    	from system calls) and asynchronous (resulting from
 	interrupts) portions of a device driver if they are
 	all executing in the same CPU.</li>
@@ -343,7 +343,7 @@ or cost of remote memory references associated with those shared
 data structures?  If the updates are few, sparse and random, there 
 may be little we can do to optimize them ... but their costs will
 not be high.  When more intensive use of shared data structures
-is required, there are two general appoaches:
+is required, there are two general approaches:
 <ol type=1>
    <li>move the data to the computation
 	<UL>

--- a/principles.html
+++ b/principles.html
@@ -22,7 +22,7 @@ We build increasingly large amounts of increasingly complex software.  Size and 
    	to see complex emergent behaviors that could not have been predicted
 	from our experience with smaller systems.
    <li> increasingly rich functionality and interactions with increasingly many
-   	other external systems make complete testing combinatoricially impossible.</li>
+   	other external systems make complete testing combinatorically impossible.</li>
    <li> our increasing dependency on this software means that failures will cause
    	more severe problems, for more people, more often.</li>
 </ul>
@@ -35,7 +35,7 @@ software:
 <ul>
    <li>	They involve complex interactions among many sub-systems.</li>
    <li> They involve numerous asynchronous interactions and externally originated events.</li>
-   <li> They involve the sharing of statefull resources among cooperating parallel processes.</li>
+   <li> They involve the sharing of stateful resources among cooperating parallel processes.</li>
    <li> They involve coordinated actions among heterogenous components in large 
    	distributed systems.</li>
    <li> They must evolve to meet ever-changing requirements.</li>
@@ -69,7 +69,7 @@ components) understandable, we must break the system down into smaller component
 <em>that can be understood individually.</em>
 </p>
 <p>
-Hiearchical decomposition is the process of decomposing a system in a top-down fashion.
+Hierarchical decomposition is the process of decomposing a system in a top-down fashion.
 If we wanted to describe the University of California, we might
 <ul>
    <li>Start by dividing it into the Regents, the Office of the President, and the campuses.</li>
@@ -100,7 +100,7 @@ and most functions can be carried out within a particular component, the respons
 and relationships are much simplified, and it becomes possible to understand, and to manage the system.
 </p>
 <P>
-Hiearchical structure is a very effective approach to designing or understanding complex systems.
+Hierarchical structure is a very effective approach to designing or understanding complex systems.
 But the operation of these systems is not always strictly hierarchical.
 If we drill down into the details, we see that not all interaction is constrained to follow 
 the tree.  
@@ -230,7 +230,7 @@ greater flexibility to the implementers.
 </P>
 <P>
 Obviously a better abstracted interface is easier for the intended clients.
-But even if the internal implemention was well suited to the intended clients,
+But even if the internal implementation was well suited to the intended clients,
 exposing implementation details would:
 <ol type="a">
    <li>	expose more complexity to the client, making the interface
@@ -317,7 +317,7 @@ out-of-spec way (e.g. exploiting an undocumented feature), problems
 are likely to arise, in the future, perhaps resulting in a system failure.  
 </P>
 <P>
-It both logistically and combinatoricially infeasible for every developer to test every change with
+It both logistically and combinatorically infeasible for every developer to test every change with
 every combination of components (and component versions) from every
 other developer.  Interface contracts are our first line of
 defense against incompatible changes.

--- a/realtime.html
+++ b/realtime.html
@@ -81,7 +81,7 @@ may have a few characteristics that make scheduling easier:
        This enables much more intelligent scheduling.</li>
    <li><em>Starvation</em> (of low priority tasks) may be acceptable.
        The space shuttle absolutely must sense attitude and acceleration and adjust
-       spolier positions once per millisecond.  But it probably doesn't
+       spoiler positions once per millisecond.  But it probably doesn't
        matter if we update the navigational display once per millisecond
        or once every ten seconds.  Telemetry transmission is probably
        somewhere in-between.

--- a/stability.html
+++ b/stability.html
@@ -199,7 +199,7 @@ breaking <em>backwards compatibility</em>:
     </P></DD>
 <DT><strong>Versioned Interfaces</strong></DT>
     <DD><P>
-	Backwards comptibility requirements do not prevent us from
+	Backwards compatibility requirements do not prevent us from
 	changing interfaces; they merely require us to continue
 	providing old interfaces to old clients.
 	In many cases, it may be possible for an application to call
@@ -244,7 +244,7 @@ stability be understood, and adequate to achieve the product
 		    	incompatible changes to previously committed
 			interfaces.</li>
 		</ul>
-	   	Applications software develelopers can use this to 
+	   	Applications software developers can use this to 
 		determine which versions their software will run on,
 		and customers can use this to decide whether or not
 		they can safely upgrade to a new release.
@@ -280,7 +280,7 @@ When we design a system, and the interfaces between the independent
 components, we need to consider all of the different types of change
 that are likely to happen over the life of this system.  When we 
 specify our external component interfaces we need to have high
-confidence that will be able to accomodate all of the envisioned
+confidence that will be able to accommodate all of the envisioned
 evolution while preserving those interfaces.
 <UL>
    <LI> We might rearrange the distribution of functionality
@@ -288,7 +288,7 @@ evolution while preserving those interfaces.
 	more preservable) interface between them.
    <LI> We might design features that we may never implement,
 	just to make sure that the specified interfaces will
-	accomodate them if we ever do decide to build them.
+	accommodate them if we ever do decide to build them.
    <LI> We might introduce (seemingly) unnatural degrees of
 	abstraction in our services to ensure that they
 	leave us enough slack for future changes.

--- a/usermodethreads.html
+++ b/usermodethreads.html
@@ -65,7 +65,7 @@ The basic model is:
     <li>When a thread exited, we would free its stack and thread descriptor.</li>
 </ul>
 Eventually people wanted preemptive scheduling to ensure good interactive 
-response and prevent buggy threads from tieing up the application:
+response and prevent buggy threads from tying up the application:
 <ul>
     <li>Linux processes can schedule the delivery of (SIGALARM) timer
         signals and register a handler for them.</li>

--- a/workingsets.html
+++ b/workingsets.html
@@ -149,7 +149,7 @@ similar affect.  The clock hand position was a surrogate for age:
    <li>the most recently examined pages are immediately behind the hand.</li>
    <li>the pages we examined longest ago are immediately in front of the hand.</li>
    <li>if the page immediately in front of the hand has not be referenced since
-       the last time it has been scaned, it must be very old ... even if it
+       the last time it has been scanned, it must be very old ... even if it
        is not actually the oldest page in memory.</li>
 </ul>
 <P>
@@ -218,7 +218,7 @@ a process that needs another page <em>steals</em> it from a process that
 does not seem to need it as much.
 <ul>
    <li> Every process is continuously losing pages that it has not
-        recently refrenced.</li>
+        recently referenced.</li>
    <li> Every process is continuously stealing pages from other processes.</li>
    <li> Processes that reference more pages more often, will accumulate
         larger working sets.</li> 


### PR DESCRIPTION
I noticed several misspellings when I was reading some of these pages as part of my OS course. I ran all of the files through a spell-checker and made fixes where I felt they were appropriate. I only decided to make changes where I felt the mistake and solution were obvious.